### PR TITLE
Load org.el not only compile-time but also runtime

### DIFF
--- a/org-wc.el
+++ b/org-wc.el
@@ -22,8 +22,8 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'org)
-                   (require 'cl))
+(eval-when-compile (require 'cl))
+(require 'org)
 
 (defun org-wc-in-heading-line ()
   "Is point in a line starting with `*'?"


### PR DESCRIPTION
This package uses org.el functions so it should also load org.el at runtime.
And this change fixes following byte-compiles.

```
org-wc.el:182:1:Warning: the following functions might not be defined at runtime:
    org-get-tags-at, outline-next-heading, org-at-block-p,
    org-at-comment-p, org-at-drawer-p, outline-previous-heading,
    org-narrow-to-subtree, org-add-hook, org-get-valid-level,
    org-move-to-column, org-add-props
```